### PR TITLE
Feat/add tests action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,5 +23,12 @@ services:
     depends_on:
       - test-db
       - test-redis
+    command: sh -c "/wait && python manage.py test 2> /code/test-artifacts/stderr.log > /code/test-artifacts/stdout.log"
+    environment:
+      - WAIT_HOSTS=test-db:5432
+      - WAIT_HOSTS_TIMEOUT=300
+      - WAIT_SLEEP_INTERVAL=30
+      - WAIT_HOST_CONNECT_TIMEOUT=30
+      - WAIT_BEFORE_HOSTS=60
     volumes:
       - ./test-artifacts:/code/test-artifacts

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -62,4 +62,9 @@ COPY . /code
 
 RUN ["python", "manage.py", "collectstatic", "--noinput"]
 RUN ["python", "manage.py", "compress"]
-CMD python manage.py test
+
+ENV WAIT_VERSION 2.7.2
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /wait
+RUN chmod +x /wait
+
+CMD python manage.py test 2> /code/test-artifacts/stderr.log > /code/test-artifacts/stdout.log


### PR DESCRIPTION
The message `background worker "logical replication launcher"` is an expected behaviour of Postgres.  So, it is not a memory problem.  In order to make sure `test-db` host is ready, I have added `docker-compose-wait` to wait for `test-db`.  

However, when I ran the python tests, I found 3 errors.

```
======================================================================
ERROR: test_w3c (xml2rfc_compat.tests.test_fetchers.XML2RFCFetchersTestCase)
This test fails with some old data representation. Relatons data should conform
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/xml2rfc_compat/tests/test_fetchers.py", line 76, in test_w3c
    bibitem = fetchers.w3c(ref=self.w3c_ref)
  File "/code/xml2rfc_compat/fetchers.py", line 179, in w3c
    return BibliographicItem(**results[0].body)
  File "/usr/local/lib/python3.10/dist-packages/pydantic/main.py", line 406, in __init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 1 validation error for BibliographicItem
relation -> 0 -> bibitem -> formattedref
  instance of GenericStringValue, tuple or dict expected (type=type_error.dataclass; class_name=GenericStringValue)

======================================================================
ERROR: test_doi_ref_search (bibxml.test_e2e.MyViewTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/bibxml/test_e2e.py", line 43, in test_doi_ref_search
    page.fill('#doiRefToSearch', quote_plus(ref))
  File "/usr/local/lib/python3.10/dist-packages/playwright/sync_api/_generated.py", line 8330, in fill
    self._sync(
  File "/usr/local/lib/python3.10/dist-packages/playwright/_impl/_sync_base.py", line 88, in _sync
    return task.result()
  File "/usr/local/lib/python3.10/dist-packages/playwright/_impl/_page.py", line 708, in fill
    return await self._main_frame.fill(**locals_to_params(locals()))
  File "/usr/local/lib/python3.10/dist-packages/playwright/_impl/_frame.py", line 499, in fill
    await self._channel.send("fill", locals_to_params(locals()))
  File "/usr/local/lib/python3.10/dist-packages/playwright/_impl/_connection.py", line 39, in send
    return await self.inner_send(method, params, False)
  File "/usr/local/lib/python3.10/dist-packages/playwright/_impl/_connection.py", line 63, in inner_send
    result = next(iter(done)).result()
playwright._impl._api_types.TimeoutError: Timeout 30000ms exceeded.
=========================== logs ===========================
waiting for selector "#doiRefToSearch"
============================================================

======================================================================
ERROR: test_search_refs_relaton_struct_empty_results (main.tests.test_query.QueryTestCase)
Test that search_refs_relaton_struct returns an empty list of
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/main/tests/test_query.py", line 83, in test_search_refs_relaton_struct_empty_results
    refs = search_refs_relaton_struct(*objs)
UnboundLocalError: local variable 'objs' referenced before assignment

----------------------------------------------------------------------
Ran 51 tests in 36.387s

FAILED (errors=3)
Destroying test database for alias 'default'...

```

The failed tests are needed to be fixed in order to pass the whole test suite.